### PR TITLE
Force call to window.matchMedia to work in IE10/IE11

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var dynamicMatch = typeof window !== 'undefined' ? window.matchMedia : null;
 function Mql(query, values){
   var self = this;
   if(dynamicMatch){
-    var mql = window.matchMedia(query);
+    var mql = dynamicMatch.call(window, query);
     this.matches = mql.matches;
     this.media = mql.media;
     // TODO: is there a time it makes sense to remove this listener?

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ var dynamicMatch = typeof window !== 'undefined' ? window.matchMedia : null;
 function Mql(query, values){
   var self = this;
   if(dynamicMatch){
-    var mql = dynamicMatch(query);
+    var mql = window.matchMedia(query);
     this.matches = mql.matches;
     this.media = mql.media;
     // TODO: is there a time it makes sense to remove this listener?


### PR DESCRIPTION
We ran into an issue with IE10 and IE11 where an "Invalid calling object" error is generated when line 11 of index.js is run with the dynamicMatch method. By calling window.matchMedia directly we were able to work around the issue. I'm not sure if this is the appropriate fix but thought I would bring to your attention.
